### PR TITLE
Add watch history json file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 venv/
 __pycache__
+watch-history.json


### PR DESCRIPTION
# Issue
Since the file is declared within the same folder it can accidentally push the watch history JSON file and leaked our history to the public.

https://github.com/fmmochtar/youtube-takeout-sqlite/blob/1c2a5651bbfd2268ac399b635182846f1abef564/main.py#L58

# What this PR does
To get rid of that, we need to ignore the file